### PR TITLE
feat: gated redeem()

### DIFF
--- a/abis/IIOU.json
+++ b/abis/IIOU.json
@@ -73,9 +73,29 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_marketplaceAddress",
+        "type": "address"
+      },
+      {
         "internalType": "uint256",
-        "name": "amount",
+        "name": "_participationId",
         "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_participationType",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signature",
+        "type": "bytes"
       }
     ],
     "name": "redeem",

--- a/abis/IOU.json
+++ b/abis/IOU.json
@@ -393,9 +393,29 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_marketplaceAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_participationId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_participationType",
+        "type": "string"
+      },
+      {
         "internalType": "uint256",
         "name": "_amount",
         "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signature",
+        "type": "bytes"
       }
     ],
     "name": "redeem",

--- a/contracts/interfaces/IIOU.sol
+++ b/contracts/interfaces/IIOU.sol
@@ -32,7 +32,14 @@ interface IIOU {
     ///                     SETTER                       ///
     ////////////////////////////////////////////////////////
 
-    /// @dev Issue the token.
+    /**
+     * @dev Mint the specified amount of tokens to the specified address.
+     * @param _to The address to mint the tokens to.
+     * @param _amount The amount of tokens to mint.
+     * @param _nonce The nonce used to mint the tokens.
+     * @param _expiry The expiry of the signature.
+     * @param _signature The signature used to mint the tokens.
+     */
     function issue(
         address _to,
         uint256 _amount,
@@ -41,9 +48,25 @@ interface IIOU {
         bytes calldata _signature
     ) external;
 
-    /// @dev Redeem the token.
-    function redeem(uint256 amount) external;
+    /**
+     * @dev Redeem the specified amount of tokens.
+     * @param _marketplaceAddress The address of the marketplace.
+     * @param _participationId The ID of the participation.
+     * @param _participationType The type of the participation.
+     * @param _amount The amount of tokens to redeem.
+     * @param _signature The signature used to redeem the tokens.
+     */
+    function redeem(
+        address _marketplaceAddress,
+        uint256 _participationId,
+        string memory _participationType,
+        uint256 _amount,
+        bytes calldata _signature
+    ) external;
 
-    /// @dev Burn the token.
-    function burn(uint256 amount) external;
+    /**
+     * @dev Burn the specified amount of tokens.
+     * @param _amount The amount of tokens to burn.
+     */
+    function burn(uint256 _amount) external;
 }

--- a/test/IOU.js
+++ b/test/IOU.js
@@ -341,7 +341,27 @@ describe("IOU", function () {
 
             await iou.issue(otherAccount.address, amount, nonce, expiry, signature);
 
-            await iou.connect(otherAccount).redeem(amount);
+            const iouAddress = iou.address;
+            const marketplaceAddress = ethers.constants.AddressZero;
+            const txOrigin = otherAccount.address;
+            const participationId = 1
+            const participationType = "submission"
+            const redeemAmount = amount;
+
+            const redeemMessage = ethers.utils.solidityKeccak256(
+                ["address", "address", "address", "uint256", "string", "uint256"],
+                [iouAddress, marketplaceAddress, txOrigin, participationId, participationType, redeemAmount]
+            )
+
+            const redeemSignature = await otherAccount.signMessage(ethers.utils.arrayify(redeemMessage));
+
+            await iou.connect(otherAccount).redeem(
+                marketplaceAddress,
+                participationId,
+                participationType,
+                redeemAmount,
+                redeemSignature
+            );
         });
 
         it("Should burn an IOU", async function () {


### PR DESCRIPTION
This PR introduces signature gating to the `redeem()` found in IOU contracts.

Following the implementation of: https://github.com/FlipsideCrypto/treasury/blob/b07c7658d554659285c13335985ea5880e97dd04/apps/pine-listener/src/iou/endpoints/signClaim.ts#L60 this update adds to the gating to the contract.

Contrastingly, the contract function includes all fields that **MUST** be provided to avoid easily taking advantage of exploit paths. 

To that, though, redeem still does not track nonce, nor does it track the amount distributed as one assumes that we ALWAYS want to pay out 100% of the token held given a valid signature.

Critically, this does not mean that if $IOUFlow was used in two marketplaces, they should not be immediately able to redeem the payment relative to the same signature. Individual verification must be done in the API. Therefore, the signature also checks that.

@omkarb this here is the signature we will need onchain to make sure that everything is safe and secure and that there are no onchain edge cases that allow someone to bypass the API: https://github.com/FlipsideCrypto/iou/pull/9/files#diff-84b311896e0374323c7fc1881639544cca8d019949265bcd7d8a8ca16d2ed05dR351